### PR TITLE
Jacoco e Sonar

### DIFF
--- a/comum/pom.xml
+++ b/comum/pom.xml
@@ -16,10 +16,15 @@
     <properties>
         <java.version>17</java.version>
         <testcontainers.version>1.17.6</testcontainers.version>
-        <springdoc.version>2.0.2</springdoc.version>
+        <springdoc.version>2.0.4</springdoc.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <mapstruct.processor.version>1.5.3.Final</mapstruct.processor.version>
         <logstash.logback.version>7.3</logstash.logback.version>
+        <jacoco.version>0.8.8</jacoco.version>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.language>java</sonar.language>
+        <sonar.converage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco.xml</sonar.converage.jacoco.xmlReportPaths>
     </properties>
     <dependencies>
         <dependency>
@@ -99,22 +104,16 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder -->
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
@@ -192,6 +191,30 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>br/com/exemplo/comum/api/v1/mapper/**</exclude>
+                                <exclude>br/com/exemplo/comum/api/v1/filter/**</exclude>
+                                <exclude>br/com/exemplo/comum/api/v1/model/dto/**</exclude>
+                                <exclude>br/com/exemplo/comum/api/v1/model/input/**</exclude>
+                                <exclude>br/com/exemplo/comum/core/springdoc/**</exclude>
+                                <exclude>br/com/exemplo/comum/core/security/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/comum/src/test/java/br/com/exemplo/comum/ComumApplicationTests.java
+++ b/comum/src/test/java/br/com/exemplo/comum/ComumApplicationTests.java
@@ -1,13 +1,7 @@
 package br.com.exemplo.comum;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class ComumApplicationTests {
-
-    @Test
-    void contextLoads() {
-    }
-
 }


### PR DESCRIPTION
Esta PR implementa:

- Configuração de plugin do JaCoCo para análise automática de cobertura de código;
- Configuração do envio de relatório do JaCoCo para Sonar;
- Remoção do teste unitário voltado para o carregamento de contextos do SpringBoot;.